### PR TITLE
Added section for summary posts and relevant post

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A curated list of action recognition and related area (e.g. object recognition, 
 
 ## Action Recognition
 
+### Summary posts
+* [Deep Learning for Videos: A 2018 Guide to Action Recognition](http://blog.qure.ai/notes/deep-learning-for-videos-action-recognition-review) - Summary of major landmark action recognition research papers till 2018
+
 ### Spatio-Temporal Action Detection
 * [Human Action Localization with Sparse Spatial Supervision](https://arxiv.org/pdf/1605.05197.pdf) - P. Weinzaepfel et al., arXiv2017. 
 * [Unsupervised Action Discovery and Localization in Videos](http://openaccess.thecvf.com/content_ICCV_2017/papers/Soomro_Unsupervised_Action_Discovery_ICCV_2017_paper.pdf) - K. Soomro and M. Shah, ICCV2017.


### PR DESCRIPTION
The current number of papers in the repository is extremely huge and it would probably take some time for anyone to go through all relevant papers - hence a summary section listing summary posts of research papers is helpful. I would tend to think of all possible sections to place the summary section, the top of the list is the best place since visitors would overlook it and more importantly they would start reading some papers before knowing there's a summary at the end. Hence summary of papers should before the section listing all papers.