### PR TITLE
Add mevadata.org to action recognition datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Codes for popular action recognition models, written based on pytorch, verified 
 * [UWA3D Multiview Activity II Dataset](http://staffhome.ecm.uwa.edu.au/~00053650/databases.html)
 * [Northwestern-UCLA Dataset](https://users.eecs.northwestern.edu/~jwa368/my_data.html)
 * [SYSU 3D Human-Object Interaction Dataset](http://www.isee-ai.cn/~hujianfang/ProjectJOULE.html)
+* [MEVA (Multiview Extended Video with Activities) Dataset](http://mevadata.org)
 
 ### Video Annotation
 * [Efficiently scaling up crowdsourced video annotation](http://cvrr.ucsd.edu/ece285/Spring2014/papers/Vondrick_IJCV2013.pdf) - C. Vondrick et. al, IJCV2013. [[code]](https://github.com/cvondrick/vatic)


### PR DESCRIPTION
Add http://mevadata.org to action recognition datasets. MEVA has 328 hours of ground-camera data from multiple viewpoints (and 4.6 hours of UAV video) of 100 actors engaged in both scripted and unscripted activities. Additional resources include camera metadata, activity definitions, and about 22 hours of annotations.