### PR TITLE
Added a section for Competitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A curated list of action recognition and related area (e.g. object recognition, 
  - [Action Recognition and Video Understanding](#action-recognition-and-video-understanding)
  - [Object Recognition](#object-recognition)
  - [Pose Estimation](#pose-estimation)
+ - [Competitions](#competitions)
 
 ## Action Recognition and Video Understanding
 
@@ -211,6 +212,11 @@ Codes for popular action recognition models, written based on pytorch, verified 
 * [Realtime Multi-Person 2D Pose Estimation using Part Affinity Fields](https://arxiv.org/abs/1611.08050) - Z. Cao et al, CVPR2017. [[code]](https://github.com/ZheC/Realtime_Multi-Person_Pose_Estimation) depends on the [[caffe RT pose]](https://github.com/CMU-Perceptual-Computing-Lab/caffe_rtpose.git) - Earlier version of OpenPose from CMU.
 * [DensePose](https://arxiv.org/abs/1802.00434v1) [[code]](https://github.com/facebookresearch/DensePose) - Dense pose human estimation in the wild implemented in the Detectron framework.
 * [MultiPoseNet: Fast Multi-Person Pose Estimation using Pose Residual Network](https://arxiv.org/abs/1807.04067) - M. Kocabas et al, ECCV2018. [[code]](https://github.com/salihkaragoz/pose-residual-network-pytorch)
+
+## Competitions
+
+### Competitions
+* [ActEV](https://actev.nist.gov/sdl) - Activity detection in security camera videos. Runs through 2021.
 
 ## Licenses
 License

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Codes for popular action recognition models, written based on pytorch, verified 
 ## Competitions
 
 ### Competitions
-* [ActEV](https://actev.nist.gov/sdl) - Activity detection in security camera videos. Runs through 2021.
+* [ActEV (Activities in Extended Video](https://actev.nist.gov/sdl) - Activity detection in security camera videos. Runs through 2021. Hosted by NIST.
 
 ## Licenses
 License


### PR DESCRIPTION
Competitions/leaderboards/etc. are quite popular in machine learning. There is at least one ongoing activity detection competition going on right now at NIST. I suspect adding this section will lead others to add other competitions they host or find.