### PR TITLE
Add reference to DeepLabCut

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Codes for popular action recognition models, written based on pytorch, verified 
 * [Realtime Multi-Person 2D Pose Estimation using Part Affinity Fields](https://arxiv.org/abs/1611.08050) - Z. Cao et al, CVPR2017. [[code]](https://github.com/ZheC/Realtime_Multi-Person_Pose_Estimation) depends on the [[caffe RT pose]](https://github.com/CMU-Perceptual-Computing-Lab/caffe_rtpose.git) - Earlier version of OpenPose from CMU.
 * [DensePose](https://arxiv.org/abs/1802.00434v1) [[code]](https://github.com/facebookresearch/DensePose) - Dense pose human estimation in the wild implemented in the Detectron framework.
 * [MultiPoseNet: Fast Multi-Person Pose Estimation using Pose Residual Network](https://arxiv.org/abs/1807.04067) - M. Kocabas et al, ECCV2018. [[code]](https://github.com/salihkaragoz/pose-residual-network-pytorch)
+* [DeepLabCut: markerless pose estimation of user-defined body parts with deep learning](https://www.nature.com/articles/s41593-018-0209-y) - A. Mathis et al, Nature Neuroscience 2018. [[code]](https://github.com/DeepLabCut/DeepLabCut) 
 
 ## Competitions
 


### PR DESCRIPTION
* DeepLabCut is a widely used tool for markerless keypoint estimation in Neuroscience, typically used for single or multi-animal tracking in experiments.
* See http://deeplabcut.org/ and https://github.com/DeepLabCut/DeepLabCut